### PR TITLE
Bump com.mysql:mysql-connector-j in the maven group across 1 directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>8.0.33</version>
+            <version>8.2.0</version>
         </dependency>
 
         <!-- JSP Support -->


### PR DESCRIPTION
Bumps the maven group with 1 update in the / directory: [com.mysql:mysql-connector-j](https://github.com/mysql/mysql-connector-j).


Updates `com.mysql:mysql-connector-j` from 8.0.33 to 8.2.0
- [Changelog](https://github.com/mysql/mysql-connector-j/blob/release/9.x/CHANGES)
- [Commits](https://github.com/mysql/mysql-connector-j/compare/8.0.33...8.2.0)

---
updated-dependencies:
- dependency-name: com.mysql:mysql-connector-j dependency-type: direct:production dependency-group: maven ...